### PR TITLE
chore: fix snapshot samples version

### DIFF
--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -23,14 +23,14 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <!-- {x-version-update-start::current} -->
   <dependencies>
+    <!-- {x-version-update-start:google-iam-admin:current} -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-iam-admin</artifactId>
-      <version>0.0.0</version>
+      <version>0.1.1-SNAPSHOT</version>
     </dependency>
-  <!-- {x-version-update-end} -->
+    <!-- {x-version-update-end} -->
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
When this file is initially generated, it's missing the release-please annotation.

Fixed in https://github.com/googleapis/synthtool/pull/1229
