### PR TITLE
deps: testing new protobuf version in 1.0.x branch

### DIFF
--- a/google-iam-admin/pom.xml
+++ b/google-iam-admin/pom.xml
@@ -36,6 +36,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <version>3.18.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
         <artifactId>proto-google-iam-admin-v1</artifactId>
         <version>1.0.0</version><!-- {x-version-update:proto-google-iam-admin-v1:current} -->
       </dependency>
+      <dependency>
+        <!-- override google-cloud-shared-dependencies -->
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>3.18.2</version>
+      </dependency>
 
       <dependency>
         <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
No need to review. Not going to merge this.

```
~/java-iam-admin $ mvn dependency:tree -Dincludes=com.google.protobuf:protobuf-java                  git[branch:main]
...
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ google-iam-admin ---
[INFO] com.google.cloud:google-iam-admin:jar:1.0.0
[INFO] \- com.google.protobuf:protobuf-java:jar:3.18.2:compile
[INFO] 
```